### PR TITLE
Extend tests

### DIFF
--- a/R/token.R
+++ b/R/token.R
@@ -82,16 +82,20 @@ get_token <- function(client = NULL, client_id = NULL, client_secret = NULL,
 
 token <- function(value, url, type, expires) {
   if (!inherits(value, "character")) {
+    stop("value must be a character string")
+  } else {
     if (length(value) != 1) {
-      stop("value must be a character string")
+      stop("value must consist of a single string")
     }
   }
   if (!inherits(url, "character")) {
     stop("url must be an url object")
   }
   if (!inherits(type, "character")) {
+    stop("type must be a character string")
+  } else {
     if (length(type) != 1) {
-      stop("type must be a character string")
+      stop("value must consist of a single string")
     }
   }
   token <- structure(

--- a/tests/testthat/test-supported_variables.R
+++ b/tests/testthat/test-supported_variables.R
@@ -28,6 +28,8 @@ test_that("datasource support of identifiers", {
   expect_equal(resolve_datasource(station_no = "xxxxxx-1074"), 2)
   expect_equal(resolve_datasource(station_no = "xxxxxx-1095"), 2)
   expect_equal(resolve_datasource(station_no = "xxxxxx-1069"), 2)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1060"), 2)
+  expect_equal(resolve_datasource(station_no = "xxx-SF-xxx"), 2)
   expect_equal(resolve_datasource(station_no = "xxxxxx"), 1)
 })
 

--- a/tests/testthat/test-token_usage.R
+++ b/tests/testthat/test-token_usage.R
@@ -43,3 +43,46 @@ test_that("wrong combination of client information", {
   expect_error(get_token(client_secret = client_secret))
   expect_warning(get_token(client, client_id, client_secret))
 })
+
+test_that("token should get proper inputs to instantiate", {
+  value <- "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI3YjFjMDA4Ni05ZDUyLTQzOTAtYTM"
+  token_url <- "http://download.waterinfo.be/kiwis-auth/token"
+  token_type <- "Bearer"
+  expires <- as.POSIXct("2018-10-02 15:13:28 CEST")
+
+  expect_is(token(value = value, url = token_url,
+                  type = token_type, expires = expires), "token")
+  expect_error(token(value = 123, url = token_url,
+                     type = token_type, expires = expires))
+  expect_error(token(value = c("a", "ab"), url = token_url,
+                     type = token_type, expires = expires))
+  expect_error(token(value = value, url = 123,
+                     type = token_type, expires = expires))
+  expect_error(token(value = value, url = token_url,
+                     type = 123, expires = expires))
+  expect_error(token(value = value, url = token_url,
+                     type = c("a", "ab"), expires = expires))
+})
+
+test_that("Print output of token is data type specific", {
+  value <- "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI3YjFjMDA4Ni05ZDUyLTQzOTAtYTM"
+  token_url <- "http://download.waterinfo.be/kiwis-auth/token"
+  token_type <- "Bearer"
+  expires <- as.POSIXct("2018-10-02 15:13:28 CEST")
+
+  token_info <- c("Token:",
+                  "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI3YjFjMDA4Ni05ZDUyLTQzOTAtYTM",
+                  "",
+                  "Attributes:",
+                  " url: http://download.waterinfo.be/kiwis-auth/token",
+                  " type: Bearer",
+                  " expires: 2018-10-02 15:13:28 CEST")
+
+  token <- token(value = value, url = token_url,
+                 type = token_type, expires = expires)
+  message <- capture.output(print(token))
+  show <- capture.output(show(token))
+
+  expect_equal(c(message), token_info)
+})
+


### PR DESCRIPTION
Rechecking coveralls suggested some tests that could be provided and that are currently missing. This PR handles the token tests and for the additional data providers identifiers.