### PR TITLE
Quick fix on datasource id

### DIFF
--- a/R/resolve_identifiers.R
+++ b/R/resolve_identifiers.R
@@ -22,49 +22,49 @@
 resolve_datasource <- function(station_no) {
   if (grepl(".*-1066", station_no)) {
     sprintf("Station %s belongs to Meetnet HIC", station_no)
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1072", station_no)) {
     sprintf(
       "Station %s belongs to Meetnet De Vlaamse Waterweg - HIC",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1073", station_no)) {
     sprintf(
       "Station %s belongs to Meetnet EMT - afdeling Bovenschelde",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1074", station_no)) {
     sprintf(
       "Station %s belongs HIC",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1095", station_no)) {
     sprintf(
       "Station %s belongs to Meetnet W&Znv - afdeling Zeekanaal",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1069", station_no)) {
     sprintf(
       "Station %s belongs to Meetnet Vlaamse Banken",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-1060", station_no)) {
     sprintf(
       "Station %s belongs to Rijkswaterstaat (RWS)",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else if (grepl(".*-SF-.*", station_no)) {
     sprintf(
       "Station %s belongs HIC",
       station_no
     )
-    datasource <- 2
+    datasource <- 4
   } else {
     datasource <- 1
   }

--- a/tests/testthat/test-supported_variables.R
+++ b/tests/testthat/test-supported_variables.R
@@ -22,14 +22,14 @@ test_that("variables in en and nl", {
 
 
 test_that("datasource support of identifiers", {
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1066"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1072"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1073"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1074"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1095"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1069"), 2)
-  expect_equal(resolve_datasource(station_no = "xxxxxx-1060"), 2)
-  expect_equal(resolve_datasource(station_no = "xxx-SF-xxx"), 2)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1066"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1072"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1073"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1074"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1095"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1069"), 4)
+  expect_equal(resolve_datasource(station_no = "xxxxxx-1060"), 4)
+  expect_equal(resolve_datasource(station_no = "xxx-SF-xxx"), 4)
   expect_equal(resolve_datasource(station_no = "xxxxxx"), 1)
 })
 

--- a/tests/testthat/test-variable_listing.R
+++ b/tests/testthat/test-variable_listing.R
@@ -11,7 +11,7 @@ test_that("works as expected", {
 
   expect_true(78118042 %in% overpelt$ts_id)
   expect_true("ts_id" %in% colnames(overpelt))
-  expect_true(2394848 %in% ostend$ts_id)
+  expect_true(55175010 %in% ostend$ts_id)
   expect_true("ts_id" %in% colnames(ostend))
 
   expect_equal(

--- a/vignettes/download_timeseries.Rmd
+++ b/vignettes/download_timeseries.Rmd
@@ -92,7 +92,7 @@ pet_yearly %>%
 
 (see the vignette on defining date periods for more information on the period argument used)
 
-**Remark:** the `get_stations` function only works for those measurement stations belonging to the VMM `meetnet` (network), related to the so-called `datasource = 1`. For [other networks](http://www.waterinfo.be/default.aspx?path=NL/HIC/Recent_toelichting), i.e. `datasource = 2`, the enlisting is not supported. Still, a search for data is provided starting from a given station name, as explained in the next section.
+**Remark:** the `get_stations` function only works for those measurement stations belonging to the VMM `meetnet` (network), related to the so-called `datasource = 1`. For [other networks](http://www.waterinfo.be/default.aspx?path=NL/HIC/Recent_toelichting), i.e. `datasource = 4`, the enlisting is not supported. Still, a search for data is provided starting from a given station name, as explained in the next section.
 
 ## Search identifier based on station name
 
@@ -108,14 +108,14 @@ available_variables %>% select(ts_id, station_name, ts_name,
                                parametertype_name)
 ```
 
-The available number of variables depends on the measurement station. The representation is not standardized and depends also from the type of [`meetnet`](http://www.waterinfo.be/default.aspx?path=NL/HIC/Recent_toelichting). Nevertheless, one can derive the required `ts_id` from the list when interpreting the field names. Remark that the datasource can be 2 instead of 1 for specific `meetnetten` (networks). The datasource to use is printed when asking the variables for a station. 
+The available number of variables depends on the measurement station. The representation is not standardized and depends also from the type of [`meetnet`](http://www.waterinfo.be/default.aspx?path=NL/HIC/Recent_toelichting). Nevertheless, one can derive the required `ts_id` from the list when interpreting the field names. Remark that the datasource can be 4 instead of 1 for specific `meetnetten` (networks). The datasource to use is printed when asking the variables for a station. 
 
-In order to download the 10 min time series water level data for the station in Sint-Amands tij/Zeeschelde, the `ts_id = 2810011` can be used in the `get_timeseries_tsid` function, taking into account the `datasource = 2` (default is 1):
+In order to download the 10 min time series water level data for the station in Sint-Amands tij/Zeeschelde, the `ts_id = 2810011` can be used in the `get_timeseries_tsid` function, taking into account the `datasource = 4` (default is 1):
 
 ```{r downloadstamands, fig.width = 7}
 tide_stamands <- get_timeseries_tsid("2810011", 
                                      from = "2017-06-01", to = "2017-06-05",
-                                     datasource = 2)
+                                     datasource = 4)
 ggplot(tide_stamands, aes(Timestamp, Value)) + 
     geom_line() + xlab("") + ylab("waterlevel")
 ```

--- a/vignettes/download_timeseries.Rmd
+++ b/vignettes/download_timeseries.Rmd
@@ -110,10 +110,10 @@ available_variables %>% select(ts_id, station_name, ts_name,
 
 The available number of variables depends on the measurement station. The representation is not standardized and depends also from the type of [`meetnet`](http://www.waterinfo.be/default.aspx?path=NL/HIC/Recent_toelichting). Nevertheless, one can derive the required `ts_id` from the list when interpreting the field names. Remark that the datasource can be 4 instead of 1 for specific `meetnetten` (networks). The datasource to use is printed when asking the variables for a station. 
 
-In order to download the 10 min time series water level data for the station in Sint-Amands tij/Zeeschelde, the `ts_id = 2810011` can be used in the `get_timeseries_tsid` function, taking into account the `datasource = 4` (default is 1):
+In order to download the 10 min time series water level data for the station in Sint-Amands tij/Zeeschelde, the `ts_id = 55419010` can be used in the `get_timeseries_tsid` function, taking into account the `datasource = 4` (default is 1):
 
 ```{r downloadstamands, fig.width = 7}
-tide_stamands <- get_timeseries_tsid("2810011", 
+tide_stamands <- get_timeseries_tsid("55419010", 
                                      from = "2017-06-01", to = "2017-06-05",
                                      datasource = 4)
 ggplot(tide_stamands, aes(Timestamp, Value)) + 


### PR DESCRIPTION
We found out that the datasource 2 is no longer working, but the same requests can be made on datasource 4. Changing this should ensure users to query the non-VMM stations again (although without  token support). 