### PR TITLE
Onboarding ropensci

### DIFF
--- a/R/get_stations.R
+++ b/R/get_stations.R
@@ -80,7 +80,7 @@ get_stations <- function(variable_name = NULL, frequency = "15min",
     token = token
   )
 
-  stations$content %>% select(
+  df <- stations$content %>% select(
     "ts_id", "station_latitude",
     "station_longitude", "station_id",
     "station_no", "station_name",
@@ -89,4 +89,9 @@ get_stations <- function(variable_name = NULL, frequency = "15min",
     "ts_unitsymbol",
     "dataprovider"
   )
+
+  # add request URL as df comment
+  comment(df) <- stations$response$url
+
+  return(df)
 }

--- a/R/get_stations.R
+++ b/R/get_stations.R
@@ -33,6 +33,8 @@
 #'   \item{ts_unitsymbol}{Unit of the variable.}
 #'   \item{dataprovider}{Data provider of the time series data.}
 #' }
+#' The URL of the specific request is provided as a comment attribute to the
+#' returned data.frame. Use \code{comment(df)} to get the request URL.
 #'
 #' @export
 #' @importFrom dplyr %>% select

--- a/R/get_timeseries.R
+++ b/R/get_timeseries.R
@@ -124,5 +124,8 @@ get_timeseries_tsid <- function(ts_id, period = NULL, from = NULL,
     colnames(df) <- strsplit(time_series$content$columns, ",")[[1]]
   }
 
+  # add request URL as df comment
+  comment(df) <- time_series$response$url
+
   return(df)
 }

--- a/R/get_timeseries.R
+++ b/R/get_timeseries.R
@@ -71,6 +71,9 @@
 #'      }
 #'    }
 #' }
+#' The URL of the specific request is provided as a comment attribute to the
+#' returned data.frame. Use \code{comment(df)} to get the request URL.
+#'
 #'
 #' @export
 #' @importFrom lubridate ymd_hms

--- a/R/get_variables.R
+++ b/R/get_variables.R
@@ -77,5 +77,8 @@ get_variables <- function(station_no, token = NULL) {
     datasource
   ))
 
+  # add request URL as df comment
+  comment(df) <- station_variables$response$url
+
   df
 }

--- a/R/get_variables.R
+++ b/R/get_variables.R
@@ -22,6 +22,8 @@
 #'   \item{parametertype_name}{Measured variable description.}
 #'   \item{stationparameter_name}{Station specific variable description.}
 #' }
+#' The URL of the specific request is provided as a comment attribute to the
+#' returned data.frame. Use \code{comment(df)} to get the request URL.
 #'
 #' @export
 #'

--- a/R/get_variables.R
+++ b/R/get_variables.R
@@ -63,10 +63,12 @@ get_variables <- function(station_no, token = NULL) {
 
   stations <- station_variables$content
   if (dim(stations)[1] == 2) {
-    df <- as.data.frame(t(stations[2:nrow(stations), ]))
+    df <- as.data.frame(t(stations[2:nrow(stations), ]),
+                        stringsAsFactors = FALSE)
     colnames(df) <- stations[1, ]
   } else {
-    df <- as.data.frame(stations[2:nrow(stations), ])
+    df <- as.data.frame(stations[2:nrow(stations), ],
+                        stringsAsFactors = FALSE)
     colnames(df) <- stations[1, ]
   }
 

--- a/R/supported_variables.R
+++ b/R/supported_variables.R
@@ -96,5 +96,5 @@ supported_frequencies <- function(variable_name) {
     filter(.data$variable_en == variable_name |
       .data$variable_nl == variable_name)
 
-  paste(variable_subset$frequency_en, collapse = ", ")
+  return(variable_subset$frequency_en)
 }

--- a/R/token.R
+++ b/R/token.R
@@ -1,6 +1,7 @@
 #' Get waterinfo Token
 #'
-#' Retrieve a fresh waterinfo token.
+#' Retrieve a fresh waterinfo token. A token is not required to get started,
+#' see Details section for more information.
 #'
 #' @aliases token print.token show.token expires.in expires.in.token is.expired
 #' is.expired.token
@@ -12,13 +13,19 @@
 #' @param token_url url to get the token from
 #' @param token a token object
 #'
-#' @details Either client or client_id and client_secret need to be passed as
+#' @details Notice you do not need to get a token right away to download data.
+#' For limited and irregular downloads, a token will not be required. The amount
+#' of data downloaded from waterinfo.be is limited via a credit system.
+#' When you require more extended data requests, request a download token.
+#'
+#' Either client or client_id and client_secret need to be passed as
 #' arguments. If provided, client is always used. Tokens remain valid for
 #' 24 hours, after which a fresh one must be acquired.
 #' To limit load on the server, token objects should be reused as much as
 #' possible until expiration in stead of creating fresh ones for each call.
+#'
 #' The client_id and client_secret provided in the examples are for test
-#' purposes, get your very own client via \email{hydrometrie@@waterinfo.be}!
+#' purposes, get your very own client via \email{hydrometrie@@waterinfo.be}.
 #'
 #' @return An object of class token containing the token string with the
 #' token_url, token type and moment of expiration as attributes.

--- a/README.Rmd
+++ b/README.Rmd
@@ -107,7 +107,9 @@ More detailed tutorials are available in the package vignettes!
 
 ## Note on restrictions of the downloads
 
-The amount of data downloaded from waterinfo.be is limited via a credit system. When you require more extended data requests, please request a download token from the waterinfo.be site administrators via the e-mail adress <hydrometrie@waterinfo.be> with a statement of which data and how frequently you would like to download data. You will then receive a client-credit code that can be used to obtain a token that is valid for 24 hours, after which the token can be refreshed with the same client-credit code.
+The amount of data downloaded from waterinfo.be is limited via a credit system. You do not need to get a token right away to download data. For limited and irregular downloads, a token will not be required.
+
+When you require more extended data requests, please request a download token from the waterinfo.be site administrators via the e-mail adress <hydrometrie@waterinfo.be> with a statement of which data and how frequently you would like to download data. You will then receive a client-credit code that can be used to obtain a token that is valid for 24 hours, after which the token can be refreshed with the same client-credit code.
 
 Get token with client-credit code: (limited client-credit code for testing purposes)
 

--- a/README.md
+++ b/README.md
@@ -63,20 +63,20 @@ get_stations("air_pressure")
 #> 1 78124042         51.20300          5.439589      12213   ME11_002
 #> 2 78039042         51.24379          4.266912      12208   ME04_001
 #> 3 78005042         51.02263          2.970584      12206   ME01_003
-#> 4 78107042         51.16224          4.845708      12212   ME10_011
-#> 5 78073042         50.88663          4.094898      12210   ME07_006
+#> 4 78073042         50.88663          4.094898      12210   ME07_006
+#> 5 78107042         51.16224          4.845708      12212   ME10_011
 #> 6 78022042         51.27226          3.728299      12207   ME03_017
-#> 7 78056042         50.86149          3.411318      12209   ME05_019
-#> 8 78090042         50.73795          5.141976      12211   ME09_012
+#> 7 78090042         50.73795          5.141976      12211   ME09_012
+#> 8 78056042         50.86149          3.411318      12209   ME05_019
 #>              station_name stationparameter_name parametertype_name
 #> 1             Overpelt_ME                    Pa                 Pa
 #> 2              Melsele_ME                    Pa                 Pa
 #> 3               Zarren_ME                    Pa                 Pa
-#> 4            Herentals_ME                    Pa                 Pa
-#> 5           Liedekerke_ME                    BP                 Pa
+#> 4           Liedekerke_ME                    BP                 Pa
+#> 5            Herentals_ME                    Pa                 Pa
 #> 6            Boekhoute_ME                    Pa                 Pa
-#> 7              Waregem_ME                    Pa                 Pa
-#> 8 Niel-bij-St.-Truiden_ME                    Pa                 Pa
+#> 7 Niel-bij-St.-Truiden_ME                    Pa                 Pa
+#> 8              Waregem_ME                    Pa                 Pa
 #>   ts_unitsymbol dataprovider
 #> 1           hPa          VMM
 #> 2           hPa          VMM
@@ -121,28 +121,28 @@ Another option is to check the available variables for a given station, with the
 ``` r
 vars_overpelt <- get_variables("ME11_002")
 head(vars_overpelt, 10)
-#>    station_name station_no    ts_id                    ts_name
-#> 1   Overpelt_ME   ME11_002 78118042                 KalJaarMin
-#> 2   Overpelt_ME   ME11_002 96256042 Penman.IWRS.DagTotaal.8:00
-#> 3   Overpelt_ME   ME11_002 78693042                       P.15
-#> 4   Overpelt_ME   ME11_002 78522042                 HydJaarMax
-#> 5   Overpelt_ME   ME11_002 90366042                 HydJaarMax
-#> 6   Overpelt_ME   ME11_002 78804042                 KalJaarMax
-#> 7   Overpelt_ME   ME11_002 78797042                     DagGem
-#> 8   Overpelt_ME   ME11_002 78523042                 HydJaarMin
-#> 9   Overpelt_ME   ME11_002 94682042                   MaandMin
-#> 10  Overpelt_ME   ME11_002 78382042                     DagGem
-#>    parametertype_name stationparameter_name
-#> 1                  Pa                    Pa
-#> 2                 PET                   pET
-#> 3                  Ud                  WDir
-#> 4                  Ts                 SoilT
-#> 5                  Ta             Ta(1.75m)
-#> 6                  Td                    Td
-#> 7                  Td                    Td
-#> 8                  Ts                 SoilT
-#> 9                  Ta                    Ta
-#> 10                 RH                    RH
+#>    station_name station_no    ts_id    ts_name parametertype_name
+#> 1   Overpelt_ME   ME11_002 96216042  DagTotaal         Noverschot
+#> 2   Overpelt_ME   ME11_002 78663042   MaandGem                  U
+#> 3   Overpelt_ME   ME11_002 78664042   MaandMax                  U
+#> 4   Overpelt_ME   ME11_002 78667042       P.10                  U
+#> 5   Overpelt_ME   ME11_002 78654042     DagGem                  U
+#> 6   Overpelt_ME   ME11_002 78656042     DagMin                  U
+#> 7   Overpelt_ME   ME11_002 78658042 HydJaarMax                  U
+#> 8   Overpelt_ME   ME11_002 78668042       P.15                  U
+#> 9   Overpelt_ME   ME11_002 78660042 KalJaarGem                  U
+#> 10  Overpelt_ME   ME11_002 78661042 KalJaarMax                  U
+#>    stationparameter_name
+#> 1             Noverschot
+#> 2                 WSpeed
+#> 3                 WSpeed
+#> 4                 WSpeed
+#> 5                 WSpeed
+#> 6                 WSpeed
+#> 7                 WSpeed
+#> 8                 WSpeed
+#> 9                 WSpeed
+#> 10                WSpeed
 ```
 
 Different pre-calculated variables are already available and a `ts_id` value is available for each of them to download the corresponding data. For example, `DagGem` (= daily mean values) of `RH` (= relative humidity), i.e. `ts_id = 78382042`:
@@ -177,7 +177,9 @@ More detailed tutorials are available in the package vignettes!
 Note on restrictions of the downloads
 -------------------------------------
 
-The amount of data downloaded from waterinfo.be is limited via a credit system. When you require more extended data requests, please request a download token from the waterinfo.be site administrators via the e-mail adress <hydrometrie@waterinfo.be> with a statement of which data and how frequently you would like to download data. You will then receive a client-credit code that can be used to obtain a token that is valid for 24 hours, after which the token can be refreshed with the same client-credit code.
+The amount of data downloaded from waterinfo.be is limited via a credit system. You do not need to get a token right away to download data. For limited and irregular downloads, a token will not be required.
+
+When you require more extended data requests, please request a download token from the waterinfo.be site administrators via the e-mail adress <hydrometrie@waterinfo.be> with a statement of which data and how frequently you would like to download data. You will then receive a client-credit code that can be used to obtain a token that is valid for 24 hours, after which the token can be refreshed with the same client-credit code.
 
 Get token with client-credit code: (limited client-credit code for testing purposes)
 
@@ -187,12 +189,12 @@ client <- paste0("MzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhOjRhZGE4",
 my_token <- get_token(client = client)
 print(my_token)
 #> Token:
-#> eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJkNWUxMTQ0Mi02Y2Q4LTRmYjgtYTVmYy1mMjgxNWU3NDk2ZjIiLCJpYXQiOjE1MzgzOTMwMjYsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9LaVdlYlBvcnRhbC9hdXRoIiwiYXVkIjoiMzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhIiwiZXhwIjoxNTM4NDc5NDI2fQ.cKQMj01LaYjjDV6CWP-je6xuxSurKOWlJ7FBwFdnmcg
+#> eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI0ZGMxNzI1ZC0zZDc2LTQxNGEtOTRjNS0xZWExZmI2NTY2NWIiLCJpYXQiOjE1NDM0MzY4NDAsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9LaVdlYlBvcnRhbC9hdXRoIiwiYXVkIjoiMzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhIiwiZXhwIjoxNTQzNTIzMjQwfQ.r9YjvVoCzilvHC0XLF9gOD3h32cYshhOoyjLoRtzU7U
 #> 
 #> Attributes:
 #>  url: http://download.waterinfo.be/kiwis-auth/token
 #>  type: Bearer
-#>  expires: 2018-10-02 13:23:46 CEST
+#>  expires: 2018-11-29 21:27:19 CET
 ```
 
 Receive information on the validity of the token:
@@ -215,22 +217,22 @@ Use token when retrieving data:
 get_stations(variable_name = "verdamping_monteith", token = my_token)
 #>      ts_id station_latitude station_longitude station_id station_no
 #> 1 94310042         51.02263          2.970584      12206   ME01_003
-#> 2 94530042         51.16224          4.845708      12212   ME10_011
-#> 3 94516042         50.73795          5.141976      12211   ME09_012
-#> 4 94544042         51.20300          5.439589      12213   ME11_002
-#> 5 94488042         50.86149          3.411318      12209   ME05_019
-#> 6 94460042         51.27226          3.728299      12207   ME03_017
-#> 7 94502042         50.88663          4.094898      12210   ME07_006
-#> 8 94474042         51.24379          4.266912      12208   ME04_001
+#> 2 94544042         51.20300          5.439589      12213   ME11_002
+#> 3 94530042         51.16224          4.845708      12212   ME10_011
+#> 4 94516042         50.73795          5.141976      12211   ME09_012
+#> 5 94502042         50.88663          4.094898      12210   ME07_006
+#> 6 94474042         51.24379          4.266912      12208   ME04_001
+#> 7 94488042         50.86149          3.411318      12209   ME05_019
+#> 8 94460042         51.27226          3.728299      12207   ME03_017
 #>              station_name stationparameter_name parametertype_name
 #> 1               Zarren_ME                   pET                PET
-#> 2            Herentals_ME                   pET                PET
-#> 3 Niel-bij-St.-Truiden_ME                   pET                PET
-#> 4             Overpelt_ME                   pET                PET
-#> 5              Waregem_ME                   pET                PET
-#> 6            Boekhoute_ME                   pET                PET
-#> 7           Liedekerke_ME                   pET                PET
-#> 8              Melsele_ME                   pET                PET
+#> 2             Overpelt_ME                   pET                PET
+#> 3            Herentals_ME                   pET                PET
+#> 4 Niel-bij-St.-Truiden_ME                   pET                PET
+#> 5           Liedekerke_ME                   pET                PET
+#> 6              Melsele_ME                   pET                PET
+#> 7              Waregem_ME                   pET                PET
+#> 8            Boekhoute_ME                   pET                PET
 #>   ts_unitsymbol dataprovider
 #> 1            mm          VMM
 #> 2            mm          VMM

--- a/man/get_stations.Rd
+++ b/man/get_stations.Rd
@@ -18,7 +18,9 @@
   \item{parametertype_name}{Measured variable description.}
   \item{ts_unitsymbol}{Unit of the variable.}
   \item{dataprovider}{Data provider of the time series data.}
-}}
+}
+The URL of the specific request is provided as a comment attribute to the
+returned data.frame. Use \code{comment(df)} to get the request URL.}
 \usage{
 get_stations(variable_name = NULL, frequency = "15min", token = NULL)
 }

--- a/man/get_timeseries_tsid.Rd
+++ b/man/get_timeseries_tsid.Rd
@@ -44,7 +44,9 @@
         }
      }
    }
-}}
+}
+The URL of the specific request is provided as a comment attribute to the
+returned data.frame. Use \code{comment(df)} to get the request URL.}
 \usage{
 get_timeseries_tsid(ts_id, period = NULL, from = NULL, to = NULL,
   datasource = 1, token = NULL)

--- a/man/get_token.Rd
+++ b/man/get_token.Rd
@@ -35,16 +35,23 @@ An object of class token containing the token string with the
 token_url, token type and moment of expiration as attributes.
 }
 \description{
-Retrieve a fresh waterinfo token.
+Retrieve a fresh waterinfo token. A token is not required to get started,
+see Details section for more information.
 }
 \details{
+Notice you do not need to get a token right away to download data.
+For limited and irregular downloads, a token will not be required. The amount
+of data downloaded from waterinfo.be is limited via a credit system.
+When you require more extended data requests, request a download token.
+
 Either client or client_id and client_secret need to be passed as
 arguments. If provided, client is always used. Tokens remain valid for
 24 hours, after which a fresh one must be acquired.
 To limit load on the server, token objects should be reused as much as
 possible until expiration in stead of creating fresh ones for each call.
+
 The client_id and client_secret provided in the examples are for test
-purposes, get your very own client via \email{hydrometrie@waterinfo.be}!
+purposes, get your very own client via \email{hydrometrie@waterinfo.be}.
 }
 \examples{
 # Get token via client_id and client_secret

--- a/man/get_variables.Rd
+++ b/man/get_variables.Rd
@@ -14,7 +14,9 @@
   `waterinfo.be`.}
   \item{parametertype_name}{Measured variable description.}
   \item{stationparameter_name}{Station specific variable description.}
-}}
+}
+The URL of the specific request is provided as a comment attribute to the
+returned data.frame. Use \code{comment(df)} to get the request URL.}
 \usage{
 get_variables(station_no, token = NULL)
 }

--- a/man/wateRinfo-package.Rd
+++ b/man/wateRinfo-package.Rd
@@ -31,7 +31,7 @@ Other contributors:
 \itemize{
   \item Willem Maetens \email{w.maetens@vmm.be} [contributor]
   \item Peter Desmet \email{peter.desmet@inbo.be} (0000-0002-8442-8025) [contributor]
-  \item Research Institute for Nature and Forest \email{info@inbo.be} [copyright holder]
+  \item Research Institute for Nature and Forest (INBO) \email{info@inbo.be} [copyright holder]
 }
 
 }

--- a/tests/testthat/test-station_listing.R
+++ b/tests/testthat/test-station_listing.R
@@ -5,6 +5,11 @@ test_that("Check station list dataframe output format", {
   heat_stat <- get_stations("ground_heat")
 
   expect_is(heat_stat, "data.frame")
+
+  expect_is(comment(heat_stat), "character")
+  expect_true(grepl("http://download.waterinfo.be/tsmdownload/KiWIS/KiWIS",
+                    comment(heat_stat)))
+
   expect_true(94385042 %in% heat_stat$ts_id)
   expect_false(85541042 %in% heat_stat$ts_id)
   expect_true("ts_id" %in% colnames(heat_stat))

--- a/tests/testthat/test-supported_variables.R
+++ b/tests/testthat/test-supported_variables.R
@@ -17,7 +17,7 @@ test_that("variables in en and nl", {
   freqs <- supported_frequencies("afvoer")
 
   expect_is(freqs, "character")
-  expect_true(grepl("15min", freqs))
+  expect_true("15min" %in% freqs)
 })
 
 

--- a/tests/testthat/test-timeseries_download.R
+++ b/tests/testthat/test-timeseries_download.R
@@ -9,6 +9,11 @@ test_that("Call works as expected", {
   )
 
   expect_is(pressure, "data.frame")
+
+  expect_is(comment(pressure), "character")
+  expect_true(grepl("http://download.waterinfo.be/tsmdownload/KiWIS/KiWIS",
+                    comment(pressure)))
+
   expect_equal(
     colnames(pressure),
     c("Timestamp", "Value", "Quality Code")
@@ -27,6 +32,8 @@ test_that("Response of empty dataframe", {
   )
 
   expect_is(pressure, "data.frame")
+  expect_is(comment(pressure), "character")
+
   expect_equal(
     colnames(pressure),
     c("Timestamp", "Value", "Quality Code")

--- a/tests/testthat/test-variable_listing.R
+++ b/tests/testthat/test-variable_listing.R
@@ -9,6 +9,10 @@ test_that("works as expected", {
   expect_is(overpelt, "data.frame")
   expect_is(ostend, "data.frame")
 
+  expect_is(comment(overpelt), "character")
+  expect_true(grepl("https://pro.waterinfo.be/tsmpro/KiWIS/KiWIS",
+                    comment(overpelt)))
+
   expect_true(78118042 %in% overpelt$ts_id)
   expect_true("ts_id" %in% colnames(overpelt))
   expect_true(55175010 %in% ostend$ts_id)

--- a/tests/testthat/test-variable_listing.R
+++ b/tests/testthat/test-variable_listing.R
@@ -18,6 +18,10 @@ test_that("works as expected", {
   expect_true(55175010 %in% ostend$ts_id)
   expect_true("ts_id" %in% colnames(ostend))
 
+  # all character data types
+  expect_equal(prod(sapply(overpelt, is.character)), 1)
+  expect_equal(prod(sapply(ostend, is.character)), 1)
+
   expect_equal(
     colnames(overpelt),
     c(

--- a/tests/testthat/test-variable_listing.R
+++ b/tests/testthat/test-variable_listing.R
@@ -19,8 +19,8 @@ test_that("works as expected", {
   expect_true("ts_id" %in% colnames(ostend))
 
   # all character data types
-  expect_equal(prod(sapply(overpelt, is.character)), 1)
-  expect_equal(prod(sapply(ostend, is.character)), 1)
+  expect_equal(prod(vapply(overpelt, is.character, TRUE)), 1)
+  expect_equal(prod(vapply(overpelt, is.character, TRUE)), 1)
 
   expect_equal(
     colnames(overpelt),

--- a/vignettes/download_timeseries.Rmd
+++ b/vignettes/download_timeseries.Rmd
@@ -163,3 +163,23 @@ etikhove <- get_timeseries_tsid("70346042",
 ggplot(etikhove, aes(Timestamp, Value)) + 
     geom_line() + xlab("") + ylab("Q (m3/s)")
 ```
+
+## Check the URL used to request the data
+
+As each of these data requests is actually a call to the [waterinfo.be](https://www.waterinfo.be/) API, the call can be tested in a browser as well. To retrieve the URL used to request certain data (using `get_variables`, `get_stations` or `get_timeseries_tsid`), check the `comment` attribute of the returned `data.frame`, for example:
+
+```
+air_stations <- get_stations("air_pressure")
+comment(air_stations)
+```
+
+or 
+
+```
+etikhove <- get_timeseries_tsid("70346042", 
+                                from = "2010-11-09", to = "2010-11-16")
+comment(etikhove)
+```
+
+
+


### PR DESCRIPTION
This PR tackles the suggestions provided by the [ropensci onboarding review](https://github.com/ropensci/onboarding/issues/255#issuecomment-442282220):

> Maybe you could add a description to the get_token help file that states up front that you do not need to get a token right away. I was just randomly walking through the examples and tried that one towards the beginning. I then went back to the README to realize I didn't need to do it.

Good suggestion, adapted both the roxygen header of the `get_token` function as well as the `Readme.md` file.

> Seems like this package would be a prime candidate for language translation. The little bit I looked into this awhile back, I think this SO post could get you started:
https://stackoverflow.com/questions/29093673/how-to-translate-package-content

@peterdesmet what about this suggestion? I understand the idea, but as we are not controlling the error messages neither the dutch fields embedded in the waterinfo.be website, how could we properly provide this kind of translated version? Ideas/suggestions are welcome, but I would say to keep is as such.

> I wonder if `supported_frequencies()` would make more sense to output a vector?

Good point, as such users can iterate over these frequencies or subset them. Adapted (and adapted test).

> There are a lot of Factors returned, but a character vector now-and-then. Factors work great for the plots, maybe not so great for other purposes. I'd double-check that the columns that are coming back as Factors make sense to be factors.

Checked this and the main issue is the `get_variables` function, returning all factors instead of characters. I would keep it to characters by default as suggested. Adapted (and added test).

> `resolve_datasource`...is this a function the general user will use? If not, maybe make it an internal function.

Available to the user, as it sometimes could be useful to have a quick check or control on the datasource (1 or 4 for the moment) themselves. hence, keep it public.

> It might be useful to the user to offer a way to see or save the URL/GET query of the retrieved data. I'm not sure the best way, one could just be a message when retrieving, one way could be to add it to the attribute of the data.frame. (for the user, they may need to use it to cite the data, for you, you might need to use it when troubleshooting problems)

Great suggestion! I found a possible solution to add the URL of the response as a `comment` attribute to the returned `data.frame`. As such we can actually check the URL later... Updated roxygen documentation and tests as well. 

